### PR TITLE
[M] design-system.md + 색 토큰 코드화 (#9)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,19 +1,331 @@
-# design-system.md
+# design-system.md — Pill Pouch 디자인 시스템
 
-> **Status**: stub. W1-4에서 채움.
+> **Status**: V1 시각 SoT (W1-4, Issue [#9](https://github.com/kswift1/PillPouch/issues/9)).
+> 모든 시각 결정의 단일 소스. 변경은 PR + 가설 B 체크 + 변경 이력 갱신.
 
-기획서 §시각 언어 + §봉지 상태 5종 + §핵심 인터랙션 명세 참조 (`brief.md`).
+---
 
-## 채울 항목
-- [ ] 색 토큰 (배경, 다크모드, 시간대 색조 아침/점심/저녁)
-- [ ] 타이포그래피 스케일
-- [ ] 스페이싱 토큰
-- [ ] 봉지 5상태 (Sealed / Active / Torn / Skipped / Missed) 시각 명세
-- [ ] 캡슐 일러스트 6종 (정제/소프트젤/캡슐/가루/액상/구미)
-- [ ] 햅틱 시퀀스 표 (드래그 진행도별)
-- [ ] 하지 말아야 할 시각 결정 목록 (기획서 그대로)
+## 1. 목적 & SoT 위계
 
-## 톤 (요약)
-- Things 3 + Streaks 교집합. 따뜻한 미니멀, 정보 밀도 낮음, 여백 많음.
-- 금기: 의료적/병원적 톤, 형광 그린·레드, 처방전 메타포, 알람 시계.
-- 지향: 자연광, 식물성, 다이어리.
+이 문서는 Pill Pouch V1 시각 결정의 단일 소스다. 색·수치·5상태 변형·캡슐 가이드·금기·하지 말아야 할 결정을 박제한다.
+
+**SoT 위계**
+
+| 위계 | 위치 | 권위 | 변경 정책 |
+|---|---|---|---|
+| 1순위 (전략·가설) | [`docs/brief.md`](brief.md) §시각 언어 | 가설 B 정합성, 정체성, Non-goals | 변경 시 **ADR 필수** ([CLAUDE.md](../CLAUDE.md) 정책) |
+| 2순위 (시각 수치) | 본 문서 | 색 hex·수치·5상태 변형 | PR만으로 변경 가능. 단, 가설 B 약화 또는 brief 본문 모순 시 **ADR 필수** |
+| 3순위 (구현 토큰) | [`ios/PillPouch/DesignSystem/Tokens/`](../ios/PillPouch/DesignSystem/Tokens) | Swift 코드 토큰. 본 문서와 1:1 일치 | 본 문서 수정 시 동시 갱신 |
+
+본 문서가 brief의 "시각 언어" 섹션을 풀어쓴 sub-SoT다. 모순 발견 시 brief가 우선이며 본 문서를 수정한다 (반대 X).
+
+가설 B (기록 신뢰성) 강화 여부가 시각 결정의 평가 기준이다. "예쁜가?"가 아니라 "이 시각이 가설 B를 강화하는가?"
+
+---
+
+## 2. 톤 / 금기 / 지향
+
+### 톤
+- **결**: Things 3 + Streaks 교집합. 따뜻한 미니멀, 정보 밀도 낮음, 여백 많음.
+- **레퍼런스**: Things 3 (체크 결), Streaks (누적 시각화), Pokemon Sleep (캡슐 친근함), Bearable (픽토그램), Apple Fitness (Live Activity).
+- **결 X**: Pixar 풍 강한 캐릭터, 게임 UI, 스타트업 SaaS의 차가운 카드.
+
+### 금기 (안 씀)
+- ❌ 의료/병원 톤 — 흰 가운, 처방전, 청진기 메타포
+- ❌ 형광 그린 (`#34C759` iOS 시스템 그린류) — "성공" 이지만 약 알람 톤 환기
+- ❌ 형광 레드 (`#FF3B30` iOS 시스템 레드류) — "실패/경고" 톤 환기
+- ❌ 처방전 폰트 (Courier·필기체)
+- ❌ 알람 시계 아이콘 / 종 아이콘
+- ❌ 체크 마크(✓) 아이콘 — 가설 B는 "체크"가 아니라 "찢김"
+
+### 지향
+- ✅ 자연광 톤 (오프화이트, 따뜻한 차콜)
+- ✅ 식물성 그라디언트 (옐로우→코랄→인디고)
+- ✅ 다이어리 정서 (종이 결, 절취선)
+- ✅ 단색 픽토그램 (색은 토큰으로 동적 주입)
+
+---
+
+## 3. 색 토큰
+
+### 3.1 배경 / Surface / Stroke / Text
+
+| 토큰 | 라이트 hex | 다크 hex | 사용처 |
+|---|---|---|---|
+| `background` | `#FAF7F2` | `#1C1A17` | 앱 루트 배경. 순수 흰/검 X |
+| `surface` | `#FFFFFF` | `#26231F` | 카드, 봉지 띠 컨테이너 |
+| `stroke` | `#E8E2D8` | `#3A352F` | 카드 1pt 보더, 절취선 점선 |
+| `textPrimary` | `#2C2823` | `#F2EEE6` | 본문 |
+| `textSecondary` | `#7A736B` | `#9E978D` | 캡션, 부가 설명 |
+
+### 3.2 시간대 색조
+
+봉지 1일분 띠의 슬롯별 배경/스트로크 색조. 5상태 중 Active/Sealed 봉지의 비닐 hint 색으로 동적 주입.
+
+| 시간대 | 토큰 | 라이트 hex | 다크 hex | 분위기 |
+|---|---|---|---|---|
+| 아침 | `morning` | `#F5C56B` | `#C9A157` | warm yellow, 자연광 |
+| 점심 | `lunch` | `#E89A78` | `#B97155` | mid coral / 살구 |
+| 저녁 | `evening` | `#7B6BA8` | `#5E5283` | cool indigo / 라벤더 |
+
+**다크모드 정책**: 라이트 hex의 V값 약 70% (`HSB.V × 0.7`) + S값 5~10% 낮춤. 차콜 배경 위에서 봉지가 떠 보이도록 명도 낮추되 채도 유지하면 너무 튐 → S도 조절. 1차 휴리스틱 — 도그푸딩 D7 후 V1.1 조정 가능.
+
+### 3.3 다크모드 베이스 정책
+
+- 순수 검정 (`#000000`) **사용 X** — 차콜 (`#1C1A17`) 베이스
+- "위에 띄운 봉지 비닐" 시각 위해 surface는 베이스보다 한 단계 밝음 (`#26231F`)
+- OLED burn-in 우려는 V1 무시 (Live Activity는 시스템 배경 자체)
+
+### 3.4 채도 감소 공식 (Skipped / Missed 봉지)
+
+HSB 색공간에서 다음 공식 적용:
+
+```
+S_new = S_base × (1 − p)
+V_new = V_base
+```
+
+| 상태 | p (감소 비율) | 설명 |
+|---|---|---|
+| Skipped | 0.40 | 봉지 봉인 + dashed stroke |
+| Missed | 0.50 | 살짝 기울어짐 + 알파 0.7 |
+
+곱셈식 명시 — 뺄셈 X (S=0.2일 때 S − 0.4가 음수 되는 케이스 방지).
+
+---
+
+## 4. 타이포그래피
+
+### 4.1 기본 정책
+
+- **폰트**: 시스템 폰트 (`design: .rounded`) — Pretendard 미사용 V1
+- **Dynamic Type 지원 필수** — fixed point size 사용 X
+- 결: Things 3의 둥근 결 + 한글 시스템 폰트 자연스러운 조합
+
+### 4.2 토큰
+
+| 토큰 | iOS Font | 사용처 |
+|---|---|---|
+| `titleL` | `.system(.largeTitle, design: .rounded).weight(.semibold)` | Today 헤더 날짜 |
+| `titleM` | `.system(.title2, design: .rounded).weight(.semibold)` | 섹션 제목 ("쌓인 증거") |
+| `body` | `.system(.body, design: .rounded)` | 본문, 영양제 이름 |
+| `caption` | `.system(.caption, design: .rounded)` | 캡션, 부가 설명 |
+| `mono` | `.system(.body, design: .monospaced)` | 슬롯 시각 표시 (`08:00` 등) — rounded와 결 다름 의도적 |
+
+---
+
+## 5. 스페이싱
+
+### 5.1 정책
+
+- **8pt grid** — Apple HIG 권장 + 4pt 보조
+- 토큰 외 magic number 사용 금지 (예외: 봉지 비율 같은 시각 명세는 % 단위로 §6에 박제)
+
+### 5.2 토큰
+
+| 토큰 | pt | 용도 예시 |
+|---|---|---|
+| `xs` | 4 | 인라인 아이콘 ↔ 텍스트 |
+| `sm` | 8 | 카드 내 세로 간격 |
+| `md` | 16 | 섹션 내 일반 간격 |
+| `lg` | 24 | 카드 ↔ 카드, 섹션 패딩 |
+| `xl` | 32 | 섹션 ↔ 섹션 |
+| `xxl` | 48 | 화면 상단 여백 |
+
+---
+
+## 6. 봉지 5상태 시각 명세
+
+> **W2 (L) 가로 드래그 task의 입력값 SoT.** 본 섹션 변경 = W2 컴포넌트 재작업.
+
+### 6.1 봉지 기본 수치
+
+| 항목 | 값 | 메모 |
+|---|---|---|
+| 비율 (가로:세로) | **100 : 32** | iPhone 세로 화면에 봉지 3개 세로 스택 + 캡슐 식별 마진. W2 시뮬 후 ±2%pt 조정 가능 |
+| 비닐 반투명도 (라이트) | 알파 **0.85** | 안 캡슐 약 60% 비침 |
+| 비닐 반투명도 (다크) | 알파 **0.75** | 차콜 위 가독성 |
+| V자 컷 위치 | 상단 좌측에서 가로 **12%** 안쪽 | |
+| V자 컷 깊이 | 봉지 높이의 **22%** | 32pt 표시 시 시각 확보 (98pt × 22% ≈ 22pt) |
+| 찢김 경로 | 베지어 + sine 노이즈 | amplitude **2.0pt**, period **8pt** — @2x도 보임 |
+| 찢긴 윗 조각 매달림 각도 | **12°~18°** 랜덤 (seed = 봉지 ID) | 결정적 — 같은 봉지는 항상 같은 각도 |
+| 100% 찢김 시 캡슐 노출 면적 | 봉지 면적의 약 **65%** | |
+| 그림자 | y=2, blur=4, alpha **0.08** 고정 | 시간대 색조 X, 모드 무관 |
+
+> **도그푸딩 게이트**: 비닐 알파(0.85/0.75)는 도그푸딩 D7 후 ±0.05 범위 조정 가능. V1.0 출시는 0.85/0.75 고정.
+
+### 6.2 5상태 변형 표
+
+| # | 상태 | 이름 | 시각 | 사용 시점 |
+|---|---|---|---|---|
+| 1 | Sealed | 봉인 | 기본 (위 6.1 수치 그대로). 비닐 안 캡슐 60% 비침. V자 컷 자국. | 미체크 + 시간 슬롯 도달 전 |
+| 2 | Active | 활성 (NOW) | Sealed + 그림자 alpha **0.16** + 시간대 색조 alpha **0.12** outer ring (미세 글로우) | 현재 슬롯 시각 도달, 미체크 |
+| 3 | Torn | 찢김 | 상단 path 분리 (찢긴 윗 조각, 매달림 각도 12~18°) + 하단 path (캡슐 노출 65%). 비가역적 시각 증거. | 사용자가 봉지 찢어 기록 |
+| 4 | Skipped | 건너뜀 | Sealed + stroke `dashed 4-2pt` + 채도 `S × 0.6` (감소 0.40) | 사용자가 명시적으로 건너뛴 슬롯 |
+| 5 | Missed | 누락 | Sealed + rotation **−3°** (정적 상태만, 드래그 중 0°) + 채도 `S × 0.5` + 알파 0.7 | 슬롯 시각 지났는데 미체크 |
+
+### 6.3 가설 B 정합성 체크
+
+- ✅ Torn 상태가 비가역적 시각 증거 — "찢김"이 본질이며 체크/원형/✓ 회피
+- ✅ Sealed↔Torn 차이가 "있다/없다" 수준 (캡슐 노출 65%)으로 명확 — 의문 즉시 해소
+- ✅ Skipped/Missed가 Sealed/Torn과 시각적으로 구분되어 "쌓인 증거"가 정확
+- ❌ 회피: Sealed 위에 ✓ 표시, 색만 바뀌는 체크, 알파만 변하는 처리
+
+### 6.4 텍스처 / 종이 결 (V1.1)
+
+종이 결, 인쇄 도트 노이즈, 봉지 표면 그레인은 V1.0 미포함. V1.1 후순위. V1.0은 코드 그라디언트만으로 비닐 표현.
+
+---
+
+## 7. 캡슐 일러스트 6종
+
+> **자산 제작은 [Issue #11](https://github.com/kswift1/PillPouch/issues/11) (W2)** 에서. 본 섹션은 명세 + 프롬프트 SoT.
+
+### 7.1 공통 SVG 명세
+
+- 라인 두께 **1.5pt**, 코너 라운드 **2pt**
+- 모노크롬 단색 fill (캡슐만 예외 — 2-tone 허용) + 1 hint dot (흰색 광점)
+- **Template Image** (`fill="currentColor"`) — `.foregroundStyle(PPColor.morning)` 동적 색 주입
+- **Asset Catalog Symbol Image 등록** — `Capsules/<name>.symbolset/`
+- 32pt 표시 시 6종 식별 가능 — 라벨 없이 5명 중 4명 이상 맞히면 통과
+
+### 7.2 6종 명세 표
+
+| 캡슐 | viewBox | 색 정책 | 식별 핵심 |
+|---|---|---|---|
+| `tablet` (정제) | 24×24 | 단색 | 원통 옆면, 가운데 score line |
+| `softgel` (소프트젤) | 24×24 | 단색 + 흰 광점 | 길쭉 타원, 광택 |
+| `capsule` (캡슐) | 24×24 | **2-tone 상하 분리** | 양쪽 반원 + 깔끔한 접합선 |
+| `powder` (가루) | 20×28 | 단색 + 작은 dot pattern | 스틱팩 직사각, 톱니 상단, 안쪽 작은 점 5~8개 |
+| `liquid` (액상) | 20×28 | 단색 + 작은 inner highlight | 물방울, 안쪽 살짝 fill (hollow 아님) |
+| `gummy` (구미) | 24×24 | 단색 + 흰 광점 | **rounded blob 실루엣** (곰돌이/별 X — 성인 친화) |
+
+### 7.3 GPT Image 2 프롬프트 6개
+
+GPT Image 2 (2026-04-21 출시) — OpenAI 공식 가이드의 `Style → Subject → Details → Constraints → Use case` 라벨 구조 채택. `quality="high"` 권장.
+
+#### 공통 라벨 블록 (각 프롬프트 머리/꼬리에 그대로 사용)
+
+```
+Style: minimalist flat pictogram, vector-like clean shapes, no gradients, no shadows, no outlines except 1.5pt stroke if needed, plain pure white background
+Use case: mobile app pictogram for an adult vitamin tracking app, must read clearly at 24px
+Constraints: single centered subject with generous padding (subject occupies ~60% of frame), no text, no watermark, no logos, no medical iconography (no cross, no Rx), no shadow, friendly but not childish, scalable silhouette
+```
+
+#### 개별 Subject + Details
+
+**1. tablet (정제)**
+```
+Subject: a round white pill tablet viewed from the side
+Details: short cylinder shape, soft rounded edges, a single horizontal score line across the middle, single fill color
+```
+
+**2. softgel (소프트젤)**
+```
+Subject: an oval softgel capsule, slightly glossy
+Details: smooth elongated egg shape, one small white highlight dot in the upper-left, single fill color, line weight 1.5pt
+```
+
+**3. capsule (캡슐)** — *2-tone 명시, 공통 라벨의 "single fill color"는 본 항목에서 무시 명시*
+```
+Subject: a two-tone medication capsule, horizontal orientation
+Details: pill capsule split into two equal halves by a clean vertical seam line, top half one color, bottom half a slightly darker shade, no other detail
+Override: two fill colors allowed for this icon (not single color)
+```
+
+**4. powder (스틱팩 가루)**
+```
+Subject: a vertical powder stick pack sachet
+Details: tall rectangular pouch (proportions 20:28), small zigzag serrated edge on the top, 5 to 8 tiny solid dots scattered inside the lower two-thirds suggesting powder, single fill color for the pouch outline
+```
+
+**5. liquid (액상 드롭)**
+```
+Subject: a single liquid droplet
+Details: classic teardrop shape with rounded bottom and pointed top, a small lighter fill area inside near the upper-left as inner highlight (not hollow), single fill color outline
+```
+
+**6. gummy (구미)**
+```
+Subject: a soft rounded blob of gummy candy
+Details: irregular but symmetric pebble shape with smooth rounded edges, one small white highlight dot near the top, single fill color, no facial features, no animal shape
+```
+
+### 7.4 정리·등록 워크플로우 (#11에서 진행)
+
+1. 작업지시자가 GPT Image 2로 위 6개 프롬프트 실행 (`quality="high"`, 각 4~8장 후 1개 선택)
+2. Figma/Illustrator import → outline 단순화 → 단색 path만 남기고 SVG export (viewBox 통일 24×24 또는 20×28, `fill="currentColor"`)
+3. `ios/PillPouch/Assets.xcassets/Capsules/{tablet,softgel,capsule,powder,liquid,gummy}.symbolset/` 등록 (Symbol Image, Template Image)
+4. 32pt 표시 시 6종 식별성 자체 검증 (5명 중 4명 이상) → 부족하면 프롬프트 조정 후 재생성
+
+---
+
+## 8. 햅틱 시퀀스
+
+> **W2 (L) 가로 드래그 task의 입력값 SoT.** 코드 구현은 W2.
+
+### 8.1 드래그 진행도별 햅틱 표
+
+| 진행도 | 시각 변화 | 햅틱 generator | 강도 / 횟수 |
+|---|---|---|---|
+| 0% (대기) | 봉지 봉인. V자 컷 자국. | — | — |
+| 0~30% | V자 컷에서 살짝 갈라지기 시작 | `UIImpactFeedbackGenerator(style: .soft)` | intensity 0.4, 진행도 5%마다 1회 (총 ~6회) |
+| 30~70% | 봉지 윗부분이 따라 찢어짐. 종이 찢는 지그재그 가장자리. | `UIImpactFeedbackGenerator(style: .soft)` | intensity 0.7, 진행도 4%마다 1회 (총 ~10회) |
+| 70~100% | 윗 조각이 살짝 들리거나 떨어짐. 캡슐 노출 시작. | `UIImpactFeedbackGenerator(style: .soft)` | intensity 1.0, 진행도 3%마다 1회 (총 ~10회) |
+| 100% 도달 | 봉지 "찢김" 상태로 고정. 캡슐이 빠져나간 자리. | `UINotificationFeedbackGenerator().notificationOccurred(.success)` | 한 번 |
+
+기획서 §핵심 인터랙션 명세 표를 수치 정밀화. 총 5~7회 → 측정 후 26회 (5%→4%→3% 진행 간격 단조감소). 도그푸딩에서 너무 많으면 W2에서 간격 조정.
+
+### 8.2 50% 임계 (오탭 방지)
+
+- **50% 미만에서 손 떼기** → `withAnimation(.spring(response: 0.4, dampingFraction: 0.6))` 스프링 백 (0%로). 햅틱 X.
+- **50% 이상에서 손 떼기** → 자동으로 100%까지 진행, 햅틱 시퀀스 계속 + `.success` 발사.
+
+### 8.3 Undo 토스트
+
+- 100% 완료 후 5초 토스트 (`.success` 햅틱과 분리, 동시 X)
+- 토스트 탭 시 햅틱 X (시각 reset만)
+
+---
+
+## 9. 하지 말아야 할 시각 결정
+
+> 기획서 §하지 말아야 할 시각 결정 + 본 문서에서 추가.
+
+- ❌ **봉지 위에 노란 동그라미 ✓ 표시 = 체크 메타포** — 가설 B 약화. "찢김"이 증거다.
+- ❌ **찢긴 봉지 안 캡슐이 흐릿함** — "먹었음" 명확하지 않음. 캡슐은 명확히 노출.
+- ❌ **Carousel/스와이프로 슬롯 전환** — 의문 해소가 즉시 일어나려면 모든 슬롯이 한 화면에.
+- ❌ **단순 탭 체크** — 오탭 위험 + 의도성 부재. 드래그 찢기로만.
+- ❌ **"드래그해서 찢어주세요" 안내 카피 메인 박기** — 온보딩 1회만.
+- ❌ **"0% / 30% / 70% / 100%" 진행 시퀀스 메인 박기** — 봉지가 자체로 표현.
+- ❌ **의료 톤 (흰 가운, 처방전, 청진기, 십자가, Rx 약자)** — 정체성 충돌.
+- ❌ **알람 시계 / 종 아이콘** — A(보조) 강조 — B(메인) 약화.
+- ❌ **형광 그린/레드** (`#34C759`, `#FF3B30` 류) — 따뜻한 결 깸.
+- ❌ **순수 검정 / 순수 흰색 배경** — 차콜 / 오프화이트만.
+- ❌ **Pixar 풍 강한 캐릭터, 게임 UI 글래스모피즘** — Things 3 결과 충돌.
+- ❌ **봉지 5상태를 색만으로 구분** — 형태 변화(찢김·기울어짐·dashed)가 본질.
+- ❌ **캡슐 6종을 색으로 구분** — 형태로 식별. 색은 시간대 슬롯 정보.
+- ❌ **Dynamic Type 무시한 fixed point size** — 접근성 의무.
+
+---
+
+## 10. 변경 이력
+
+### W1-4 (2026-04-28, Issue #9, PR TBD)
+- 초기 작성
+- 시간대 색조 (아침/점심/저녁) 라이트+다크 hex 박제
+- 봉지 5상태 수치 SoT (비율 100:32, V컷 22%, sine 2.0pt, 채도 공식)
+- 캡슐 6종 SVG 명세 + GPT Image 2 프롬프트 6개
+- 햅틱 시퀀스 표 정밀화
+- 하지 말아야 할 시각 결정 14개
+
+---
+
+## 11. 참고
+
+- 상위 SoT: [`docs/brief.md`](brief.md) §시각 언어
+- 구현 토큰: [`ios/PillPouch/DesignSystem/Tokens/`](../ios/PillPouch/DesignSystem/Tokens)
+- ADR-0005: [`docs/adr/0005-no-tca-swiftui-native.md`](adr/0005-no-tca-swiftui-native.md) (SwiftUI 네이티브 전제)
+- 캡슐 자산: [Issue #11](https://github.com/kswift1/PillPouch/issues/11) (W2)
+- 봉지 컴포넌트: W2 (M) 봉지 5상태 컴포넌트 task (TBD)
+- 가로 드래그: W2 (L) 가로 드래그 task (TBD)

--- a/docs/plans/task_W1_9_impl.md
+++ b/docs/plans/task_W1_9_impl.md
@@ -1,0 +1,231 @@
+# task_W1_9_impl.md — design-system.md + 색 토큰 코드화 구현계획서
+
+## 메타
+
+| 항목 | 값 |
+|---|---|
+| Issue | [#9](https://github.com/kswift1/PillPouch/issues/9) |
+| 마일스톤 | W1 |
+| 크기 | M |
+| 영역 | area:design + area:ios |
+| 브랜치 | `kswift1/task9-tokens` |
+| 예상 시간 | 3~4시간 |
+
+## 목표
+
+W1까지 합의된 시각 언어를 `docs/design-system.md` SoT로 박제하고, 그중 색·스페이싱·타이포그래피만 iOS Swift 토큰으로 코드화한다. 봉지 5상태/캡슐 6종/햅틱 시퀀스는 W2에서 컴포넌트화하므로 V1 본문에서는 명세까지만 — 코드는 W2 작업.
+
+## 비목표 (이번 task에서 안 하는 것)
+
+- ❌ 봉지 5상태 SwiftUI 컴포넌트 (W2 (M) 봉지 5상태 컴포넌트 task 책임)
+- ❌ 캡슐 6종 SVG 실제 제작/등록 — **별도 issue [#11](https://github.com/kswift1/PillPouch/issues/11) (W2)** 로 분리. 본 task는 §7에 **AI 생성 프롬프트 + 정리 가이드 + 작업지시자 작업 흐름**까지 박제
+- ❌ 봉지 텍스처/노이즈 overlay (V1.1, 본 task §6에 "추후" 표시만)
+- ❌ 햅틱 코드 구현 (W2 (L) 가로 드래그 task)
+- ❌ Today 화면 통합 (W1-5 task 책임)
+- ❌ `TimeSlot` enum 정의 — W1-3 (다른 워크스페이스, `ios/PillPouch/Models/` 영역). 본 task의 색 토큰은 모델 의존 없이 독립적으로 노출 (`PPColor.morning/.lunch/.evening`)
+
+## 봉지/캡슐 구현 결정 (작업지시자 2026-04-27 승인)
+
+**하이브리드 3-레이어** 채택:
+- **L1 봉지 껍데기**: SwiftUI Shape + Path + Canvas (찢기 progress 동적 변형, 다크/시간대 색조 동적 적용)
+- **L2 캡슐 6종**: SVG 자산 (모노크롬 + 1 hint, `.foregroundStyle()` 색 주입). **AI 생성** (Midjourney/Ideogram) → 작업지시자 정리 → Asset Catalog 등록 (#11에서 진행)
+- **L3 텍스처/종이결**: V1.1 후순위, V1.0 미포함
+
+본 task는 명세 SoT만 박제. 실제 봉지 SwiftUI 컴포넌트는 W2, 캡슐 SVG는 #11.
+
+## 구현 단계 (3단계, 순차)
+
+### Step 1: `docs/design-system.md` 본문 채움
+
+기존 stub의 "## 채울 항목" 체크리스트를 모두 본문 섹션으로 풀어쓴다. 기획서 §시각 언어 / §봉지 상태 5종 / §핵심 인터랙션 명세 / §하지 말아야 할 시각 결정의 **요약 + 명세 정밀화** — 기획서를 그대로 베끼지 말고, 디자인 시스템 SoT 관점에서 토큰명·수치·매핑 표를 추가.
+
+본문 섹션 (위→아래):
+
+1. **목적 & SoT 위계 선언** — 위계 명시:
+   - **상위 SoT**: `docs/brief.md` §시각 언어 (전략·가설 B 정합성). 변경 시 ADR 필수 (CLAUDE.md 정책)
+   - **시각 수치 SoT**: 본 문서 (`docs/design-system.md`). brief를 풀어쓴 sub-SoT. 색 hex·수치·5상태 변형은 본 문서가 권위
+   - **변경 정책**: 수치/hex 변경은 PR만으로 가능. 단, 가설 B를 약화하는 시각 결정이거나 brief 본문과 모순되면 ADR 필수. 모든 변경은 §변경 이력 추가.
+2. **톤 / 금기 / 지향** — 기획서 §시각 언어 §톤 압축 + 금기 색 hex 예시 (형광 그린/레드 → `#FF3B30`, `#34C759` 회피 사례).
+3. **색 토큰**
+   - 배경 (라이트 오프화이트 `#FAF7F2`, 다크 차콜 `#1C1A17` — 순수 검정 X)
+   - 시간대 색조 표: 토큰명 / 라이트 hex / 다크 hex (살짝 채도 낮춤) / 사용처
+     - 아침 `#F5C56B` (warm yellow) / 다크 `#C9A157`
+     - 점심 `#E89A78` (mid coral / apricot) / 다크 `#B97155`
+     - 저녁 `#7B6BA8` (cool indigo / lavender) / 다크 `#5E5283`
+   - Surface / Stroke / Text 토큰 (일반)
+   - 다크모드 정책: "차콜 베이스, 시간대 색조는 채도 낮춰 유지"
+4. **타이포그래피 스케일** — 시스템 폰트(Pretendard 미사용 V1) + Dynamic Type 매핑 표 (Title L / Title M / Body / Caption / Mono — 슬롯 시각 표시 한정)
+5. **스페이싱 토큰** — 8pt grid (`xs=4, sm=8, md=16, lg=24, xl=32, xxl=48`)
+6. **봉지 상태 5종 시각 명세** — 기획서 §봉지 상태 5종 표를 풀어쓰고, **봉지 수치 SoT 표** 박제 (W2 (L) 가로 드래그 task의 입력값):
+   - 봉지 비율 가로 100% : 세로 32% (한국 1일분 봉지 + iPhone 세로 화면 3봉지 스택 시 캡슐 식별 가능 마진. 100:28은 너무 납작 → 100:32로 살짝 높임. W2 시뮬레이션 후 ±2%pt 조정 가능)
+   - 비닐 반투명도: 라이트 알파 0.85 / 다크 0.75 → 안 캡슐 60% 비침. **도그푸딩 D7 후 ±0.05 조정 게이트** 메모 (V1.0 출시는 0.85/0.75로 고정)
+   - V자 컷 위치: 상단 좌측에서 12% 안쪽 / V자 깊이: 봉지 높이의 22% (98pt × 22% ≈ 22pt → 32pt 표시 시 시각 확보)
+   - 찢김 경로: 베지어 + sine 노이즈 (amplitude 2.0pt, period 8pt — @2x도 보이도록 1.5→2.0)
+   - 찢긴 윗 조각 매달림 각도: 12~18° (랜덤, seed = 봉지 ID)
+   - 100% 찢김 시 캡슐 노출 면적: 봉지 면적의 약 65%
+   - 그림자: y=2 blur=4 alpha=0.08 (시간대 색조 X, 모드 무관 고정)
+   - **채도 감소 공식 (Skipped/Missed)**: HSB 색공간에서 `S_new = S_base × (1 - p)`. p=0.40(Skipped), p=0.50(Missed). 명도 V는 그대로.
+   - 5상태별 추가 변형:
+     - **Sealed**: 기본
+     - **Active**: 그림자 alpha 0.16, 미세 글로우 (시간대 색조 alpha 0.12 outer ring)
+     - **Torn**: 상단 path 분리 + 하단 path 캡슐 노출 + 매달림 각도 적용
+     - **Skipped**: stroke dashed 4-2pt, 채도 ×0.6, 봉지 봉인 유지
+     - **Missed**: 정적 상태에서만 rotation -3°(드래그 중 0°), 채도 ×0.5, 알파 0.7
+7. **캡슐 일러스트 6종 가이드** — 자산 제작은 [#11](https://github.com/kswift1/PillPouch/issues/11)에서. 본 섹션은 (a) 공통 SVG 명세 (b) 6종 명세 표 (c) **GPT Image 2 프롬프트 6개** (d) 정리·등록 워크플로우를 박제.
+
+   **(a) 공통 SVG 명세**
+   - 라인 두께 1.5pt, 코너 라운드 2pt
+   - 모노크롬 단색 fill (캡슐만 예외 — 2-tone 허용) + 1 hint dot (흰색, 광점)
+   - Template Image (`fill="currentColor"`) — `.foregroundStyle(PPColor.morning)` 동적 색 주입
+   - Asset Catalog Symbol Image 등록 (`Capsules/<name>.symbolset/`)
+
+   **(b) 6종 명세 표**
+   | 캡슐 | viewBox | 색 정책 | 식별 핵심 |
+   |---|---|---|---|
+   | tablet (정제) | 24×24 | 단색 | 원통 옆면, 가운데 score line |
+   | softgel (소프트젤) | 24×24 | 단색 + 흰 광점 | 길쭉 타원, 광택 |
+   | capsule (캡슐) | 24×24 | **2-tone 상하 분리** | 양쪽 반원 + 깔끔한 접합선 |
+   | powder (가루) | 20×28 | 단색 + 작은 dot pattern | 스틱팩 직사각, 톱니 상단, 안쪽 작은 점 5~8개 |
+   | liquid (액상) | 20×28 | 단색 + 작은 inner highlight | 물방울, 안쪽 살짝 fill (hollow 아님 — 식별성) |
+   | gummy (구미) | 24×24 | 단색 + 흰 광점 | **rounded blob 실루엣** (곰돌이/별 X — 성인 친화 중립) |
+
+   **(c) GPT Image 2 프롬프트 6개 (작업지시자 사용)**
+
+   GPT Image 2 (2026-04-21 출시)는 OpenAI 공식 가이드의 `Style → Subject → Details → Constraints → Use case` 라벨 구조 권장. Midjourney 플래그(`--style raw`) 사용 안 함. Quality는 `high` 권장 (small icon).
+
+   **공통 라벨 블록 (각 프롬프트 머리/꼬리에 그대로 사용)**
+   ```
+   Style: minimalist flat pictogram, vector-like clean shapes, no gradients, no shadows, no outlines except 1.5pt stroke if needed, plain pure white background
+   Use case: mobile app pictogram for an adult vitamin tracking app, must read clearly at 24px
+   Constraints: single centered subject with generous padding (subject occupies ~60% of frame), no text, no watermark, no logos, no medical iconography (no cross, no Rx), no shadow, friendly but not childish, scalable silhouette
+   ```
+
+   **개별 Subject + Details**
+
+   1. **tablet (정제)**
+      ```
+      Subject: a round white pill tablet viewed from the side
+      Details: short cylinder shape, soft rounded edges, a single horizontal score line across the middle, single fill color
+      ```
+
+   2. **softgel (소프트젤)**
+      ```
+      Subject: an oval softgel capsule, slightly glossy
+      Details: smooth elongated egg shape, one small white highlight dot in the upper-left, single fill color, line weight 1.5pt
+      ```
+
+   3. **capsule (캡슐)** — *2-tone 명시, 공통 라벨의 "single fill color"는 본 항목에서 무시 명시*
+      ```
+      Subject: a two-tone medication capsule, horizontal orientation
+      Details: pill capsule split into two equal halves by a clean vertical seam line, top half one color, bottom half a slightly darker shade, no other detail
+      Override: two fill colors allowed for this icon (not single color)
+      ```
+
+   4. **powder (스틱팩 가루)**
+      ```
+      Subject: a vertical powder stick pack sachet
+      Details: tall rectangular pouch (proportions 20:28), small zigzag serrated edge on the top, 5 to 8 tiny solid dots scattered inside the lower two-thirds suggesting powder, single fill color for the pouch outline
+      ```
+
+   5. **liquid (액상 드롭)**
+      ```
+      Subject: a single liquid droplet
+      Details: classic teardrop shape with rounded bottom and pointed top, a small lighter fill area inside near the upper-left as inner highlight (not hollow), single fill color outline
+      ```
+
+   6. **gummy (구미)**
+      ```
+      Subject: a soft rounded blob of gummy candy
+      Details: irregular but symmetric pebble shape with smooth rounded edges, one small white highlight dot near the top, single fill color, no facial features, no animal shape
+      ```
+
+   **(d) 정리·등록 워크플로우 (#11에서 작업지시자 진행)**
+   1. 작업지시자가 GPT Image 2로 위 6개 프롬프트 실행 (`quality="high"`, 각 4~8장 후 1개 선택)
+   2. Figma/Illustrator import → outline 단순화 → 단색 path만 남기고 SVG export (viewBox 통일 24×24 또는 20×28, `fill="currentColor"`)
+   3. `ios/PillPouch/Assets.xcassets/Capsules/{tablet,softgel,capsule,powder,liquid,gummy}.symbolset/` 등록 (Symbol Image, Template)
+   4. 32pt 표시 시 6종 식별성 자체 검증 (다른 사람 5명에게 라벨 없이 보여주고 4종 이상 맞히는지) → 부족하면 프롬프트 조정 후 재생성
+   - **검증 기준**: Pokemon Sleep / Bearable 픽토그램 결의 친근함, 의료 톤 X, 한 색으로 인쇄 가능한 단순도
+8. **햅틱 시퀀스 표** — 드래그 진행도 0~30/30~70/70~100/100% 별 generator 종류·강도·횟수 (기획서 §핵심 인터랙션 명세 표를 SoT로 박제). 코드 구현은 W2.
+9. **하지 말아야 할 시각 결정** — 기획서 §하지 말아야 할 시각 결정 그대로 + 추가 (의료 톤 색·알람 시계 아이콘·처방전 폰트 등).
+10. **변경 이력** — `## 변경 이력` 섹션 + W1 (이 PR) 항목.
+
+수치/hex는 SoT. iOS 토큰 코드와 1:1 일치해야.
+
+### Step 2: iOS 토큰 코드 (`ios/PillPouch/DesignSystem/Tokens/`)
+
+Xcode 프로젝트는 `PBXFileSystemSynchronizedRootGroup`(pbxproj line 32~48) 사용 — `ios/PillPouch/` 하위에 새 폴더/파일을 추가하면 자동으로 빌드 대상 포함. **pbxproj 수정 불필요.**
+
+#### 2-a. `Color+Tokens.swift`
+
+- Namespace enum `PPColor` (`enum`, no instances) — `Color.pp.morning` 식 접근 위해 `extension ShapeStyle where Self == Color`도 같이 쓸까 고민 → **단순화: `enum PPColor { static let morning: Color = ... }` 만 노출**. 사용처: `RoundedRectangle().fill(PPColor.morning)`.
+- 다크모드 동적: `Color(uiColor: UIColor { trait in trait.userInterfaceStyle == .dark ? UIColor(...darkHex) : UIColor(...lightHex) })`
+- 노출 토큰: `background`, `surface`, `stroke`, `textPrimary`, `textSecondary`, `morning`, `lunch`, `evening`
+- 내부 helper: `static func dynamic(light: UInt32, dark: UInt32) -> Color` — hex int → UIColor 변환 + trait collection 분기.
+- `unsafe_code` 류 없음, `import SwiftUI` + `import UIKit`만.
+
+#### 2-b. `Spacing.swift`
+
+- `enum PPSpacing { static let xs: CGFloat = 4; static let sm: CGFloat = 8; ... static let xxl: CGFloat = 48 }`
+- 보너스 도우미 X (`@ScaledMetric` 등은 W2 컴포넌트에서 필요할 때 도입). 지금은 단순 상수만.
+
+#### 2-c. `Typography.swift`
+
+- `enum PPFont { static let titleL: Font = .system(.largeTitle, design: .rounded).weight(.semibold); ... }`
+- `design: .rounded` 강제 (Things 3 결).
+- `Dynamic Type 지원`을 위해 `.system(_ textStyle:)` 사용 — fixed point size X.
+- 토큰: `titleL`, `titleM`, `body`, `caption`, `mono` (mono는 슬롯 시각 표시용 `.system(.body, design: .monospaced)`).
+
+#### 2-d. preview 안전성
+
+3개 파일은 모두 view를 export하지 않음 (토큰만). Preview struct 추가 X. `#Preview` 매크로 X.
+
+### Step 3: 빌드 검증 + README 색인 + 보고서 + PR
+
+- `xcodebuild -scheme PillPouch -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` 통과 확인 (CI와 동일 옵션).
+- 테스트는 옵션 — 기존 `PillPouchTests`/`PillPouchUITests`가 default 그대로면 통과. 새 테스트 추가 X (토큰 상수에 unit test는 과함, W2 컴포넌트와 함께 snapshot test 도입).
+- `docs/design-system.md` 자체가 README 역할 — `docs/README.md` 인덱스에 이미 링크가 있는지 확인하고 누락 시 추가.
+- `docs/report/task_W1_9_report.md` 작성 → 작업지시자 승인 ⛔
+- PR 생성 (가설 B 체크박스 + Non-goals 체크 포함) → squash merge.
+
+## 커밋 단위 (Conventional Commits)
+
+```
+docs: add W1-4 (#9) implementation plan
+docs(design-system): expand color, typography, spacing tokens
+docs(design-system): add pouch states, capsule, haptic specs
+feat(ios): add color, spacing, typography design tokens
+docs: add W1-4 final report
+```
+
+5 commit. Squash 후 main에 1 commit.
+
+## 위험 요소
+
+1. **워크스페이스 A(W1-3 SwiftData) 동시 작업 충돌** — `ios/PillPouch/DesignSystem/Tokens/` 신규 폴더라 충돌 없음. main에 A가 먼저 머지되면 `git fetch origin && git rebase origin/main`. pbxproj 직접 수정 안 하므로 충돌면이 거의 없음.
+2. **다크모드 hex 채도 낮춤 — 디자이너 검증 부재** — 솔로 V1, 작업지시자가 디자이너 역할. 1차 hex는 라이트 hex의 V값을 70~80%로 낮추는 휴리스틱. 도그푸딩에서 부족하면 V1.1 조정.
+3. **iOS 17.2+ API 사용 — `Color(uiColor:)`는 iOS 15+ OK** — 호환성 이슈 없음. `Font.system(_:design:)`은 iOS 13+, `.rounded` 디자인 iOS 13+, weight modifier iOS 13+.
+4. **CI ios-build paths filter** — `ios/**` 변경 있으므로 trigger됨. docs-only가 아니므로 NO_CHECKS 케이스 아님. Monitor 표준 패턴 그대로 사용.
+5. **워크스페이스 A 영역 침범 우려** — 절대 `ios/PillPouch/{Models,App,Item.swift,ContentView.swift,PillPouchApp.swift}` 수정 X. 토큰만 노출, 적용은 W1-5 (#5)에서.
+
+## 검증 (Issue #9 마감 조건)
+
+- [ ] `docs/design-system.md` — 위 Step 1의 10개 본문 섹션 모두 채움, "## 채울 항목" 체크리스트 제거 또는 [x] 처리
+- [ ] `ios/PillPouch/DesignSystem/Tokens/Color+Tokens.swift` 존재, `PPColor` enum + 8개 이상 토큰
+- [ ] `ios/PillPouch/DesignSystem/Tokens/Spacing.swift` 존재, `PPSpacing` enum + 6개 토큰 (xs~xxl)
+- [ ] `ios/PillPouch/DesignSystem/Tokens/Typography.swift` 존재, `PPFont` enum + 5개 토큰
+- [ ] `xcodebuild ... build` 로컬 통과 (CI도 자동 trigger)
+- [ ] `docs/report/task_W1_9_report.md` 작성, 작업지시자 승인
+- [ ] PR squash merge, Issue #9 자동 close
+
+## 가설 B 체크
+
+- ✅ 시간대 색조·봉지 5상태 명세 박제는 "찢긴 봉지 = 비가역적 시각 증거" 가설을 시각 토큰 단계에서 강화
+- ✅ 의료 톤·형광색·체크 메타포 회피를 코드/문서 양쪽에서 박제 → 후속 PR이 가설 약화 시각 결정을 못 하도록 가드레일
+- ✅ Non-goals(TCA, Carousel, 단순 탭) 어느 항목도 추가하지 않음
+
+## 다음 (이 task 완료 후)
+
+- W1-5 (향후 등록될 Today 정적 레이아웃 task)에서 본 토큰들을 import하여 첫 화면 구성
+- [#11](https://github.com/kswift1/PillPouch/issues/11) (W2): 작업지시자가 본 task §7의 AI 프롬프트로 캡슐 6종 생성 → SVG 정리 → Asset Catalog 등록
+- W2 (M) 봉지 5상태 컴포넌트 task에서 `PPColor.morning/lunch/evening` + 본 task §6 봉지 수치 SoT + #11 캡슐 자산을 결합한 `PouchView` 컴포넌트 구현
+- W2 (L) 가로 드래그 task에서 본 task §6 햅틱 시퀀스 + 50% 임계 + 4단계 시각 코드화

--- a/docs/report/task_W1_9_report.md
+++ b/docs/report/task_W1_9_report.md
@@ -1,0 +1,95 @@
+# task_W1_9_report.md — design-system.md + 색 토큰 코드화 최종보고서
+
+## 메타
+
+| 항목 | 값 |
+|---|---|
+| Issue | [#9](https://github.com/kswift1/PillPouch/issues/9) |
+| 마일스톤 | W1 |
+| 크기 | M |
+| 영역 | area:design + area:ios |
+| 브랜치 | `kswift1/task9-tokens` |
+| 구현계획서 | [`task_W1_9_impl.md`](../plans/task_W1_9_impl.md) |
+
+## 한 일 (구현계획서 §단계별)
+
+### Step 1: `docs/design-system.md` 본문 채움 ✅
+
+stub → 11개 본문 섹션:
+
+| § | 섹션 | 핵심 내용 |
+|---|---|---|
+| 1 | 목적 & SoT 위계 | brief(1) → design-system(2) → Swift 토큰(3) 위계 박제, 변경 정책 |
+| 2 | 톤 / 금기 / 지향 | Things 3 + Streaks 결, 의료/형광 색/체크 마크 금기 |
+| 3 | 색 토큰 | background/surface/stroke/text + morning/lunch/evening 라이트+다크 hex 표 + 채도 감소 공식 `S × (1-p)` |
+| 4 | 타이포그래피 | 시스템 `.rounded` Dynamic Type 5 토큰 |
+| 5 | 스페이싱 | 8pt grid xs..xxl 6 토큰 |
+| 6 | 봉지 5상태 | 비율 100:32, V컷 22%, sine 2.0pt, 5상태 변형 표, 도그푸딩 D7 게이트 |
+| 7 | 캡슐 6종 | SVG 명세 + GPT Image 2 프롬프트 6개 (공통 라벨 블록 + Subject/Details) + 정리 워크플로우 |
+| 8 | 햅틱 시퀀스 | 진행도별 generator/intensity/횟수 표 + 50% 임계 + Undo |
+| 9 | 하지 말아야 할 시각 결정 | 14개 항목 박제 |
+| 10 | 변경 이력 | W1-4 초기 작성 항목 |
+| 11 | 참고 | brief / 토큰 폴더 / ADR-0005 / Issue #11 / W2 task 링크 |
+
+### Step 2: iOS 토큰 코드 ✅
+
+`ios/PillPouch/DesignSystem/Tokens/` 신규 폴더 + 3 파일:
+
+| 파일 | 토큰 | 라인 수 |
+|---|---|---|
+| `Color+Tokens.swift` | `PPColor` enum + `dynamic(light:dark:)` helper. 8개 토큰 (background/surface/stroke/textPrimary/textSecondary + morning/lunch/evening). UIColor hex initializer extension. UITraitCollection 기반 라이트/다크 분기 | 30 |
+| `Spacing.swift` | `PPSpacing` enum, 8pt grid: xs=4, sm=8, md=16, lg=24, xl=32, xxl=48 | 10 |
+| `Typography.swift` | `PPFont` enum, 5 토큰: titleL/titleM (rounded semibold), body/caption (rounded), mono (monospaced) | 9 |
+
+PBXFileSystemSynchronizedRootGroup 자동 등록 — pbxproj 수정 0회.
+
+### Step 3: 빌드 검증 + Conventional Commits ✅
+
+- `xcodebuild -scheme PillPouch -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**
+- 워닝 0개 (AppIntents/AppShortcuts 관련 안내 메시지는 미사용 표시 — 워닝 X)
+- 토큰 3 파일 모두 정상 컴파일 + 링크
+
+## 커밋 단위
+
+계획서의 5 commit 안 → **3 commit** 으로 단순화 (design-system.md 11개 섹션을 한 commit으로 묶음 — split 가치 낮음):
+
+```
+82adbd5 docs: add W1-4 (#9) implementation plan
+69f602c docs(design-system): expand SoT — colors, typography, spacing, pouch states, capsule prompts, haptics
+3726bc1 feat(ios): add PPColor / PPSpacing / PPFont design tokens
+```
+
+Squash merge 시 main에 1 커밋. 본 보고서 commit 추가 시 4 commit → squash 1.
+
+## 검증 (Issue #9 마감 조건)
+
+- [x] `docs/design-system.md` — 11개 섹션 채움, stub의 "## 채울 항목" 체크리스트 제거
+- [x] `ios/PillPouch/DesignSystem/Tokens/Color+Tokens.swift` — `PPColor` 8 토큰
+- [x] `ios/PillPouch/DesignSystem/Tokens/Spacing.swift` — `PPSpacing` 6 토큰
+- [x] `ios/PillPouch/DesignSystem/Tokens/Typography.swift` — `PPFont` 5 토큰
+- [x] `xcodebuild ... build` 로컬 통과 (CI 자동 trigger 예정)
+- [ ] PR squash merge → Issue #9 자동 close (PR 생성 후)
+
+## 가설 B 체크
+
+- ✅ 시간대 색조 + 봉지 5상태 명세 박제 = 가설 B 강화 (찢김 = 비가역적 시각 증거)
+- ✅ "하지 말아야 할 시각 결정" 14개로 후속 PR 가드레일 (체크 마크/카루셀/단순 탭/의료 톤 회피)
+- ✅ Non-goals 미저촉 — TCA·Carousel·단순 탭 어느 항목도 코드/문서에 추가 X
+- ✅ 캡슐 자산 task #11 분리 — 본 task는 명세+프롬프트까지만, 자산은 W2 별도 사이클
+
+## 한 의외 발견
+
+1. **Xcode `PBXFileSystemSynchronizedRootGroup`** — Xcode 16+의 새 기능. `ios/PillPouch/` 하위에 새 폴더만 만들면 자동으로 빌드 대상 포함. pbxproj 수정 불필요. W2 봉지 컴포넌트도 같은 방식으로 추가 가능.
+2. **GPT Image 2 (2026-04-21 출시)** — Midjourney와 다른 prompting 패턴 (`Style → Subject → Details → Constraints` 라벨 구조). `--style raw` 플래그 X. 본 task §7에 형식 박제했으므로 #11 진행 시 작업지시자 그대로 사용 가능.
+3. **워크스페이스 A(W1-3 SwiftData 모델) 충돌 0건** — 신규 폴더 + 신규 파일 + pbxproj 미수정 → 면이 안 겹침. main rebase 시에도 conflict 없을 것으로 예상.
+
+## 다음 (이 task 완료 후)
+
+- **Issue #11 (W2)**: 작업지시자가 §7의 GPT Image 2 프롬프트 6개로 캡슐 SVG 생성 → Asset Catalog 등록
+- **W1-5 (등록 예정)**: Today 정적 레이아웃 — 본 task의 토큰들을 첫 화면에 import
+- **W2 (M) 봉지 5상태 컴포넌트**: §6 봉지 수치 + #11 캡슐 자산 + `PPColor.morning/lunch/evening` 결합한 `PouchView`
+- **W2 (L) 가로 드래그**: §8 햅틱 시퀀스 + 50% 임계 + 4단계 시각 코드화 (TDD)
+
+## 변경 이력
+
+- 2026-04-28: 초기 작성 (PR TBD)

--- a/ios/PillPouch/DesignSystem/Tokens/Color+Tokens.swift
+++ b/ios/PillPouch/DesignSystem/Tokens/Color+Tokens.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import UIKit
+
+enum PPColor {
+    static let background = dynamic(light: 0xFAF7F2, dark: 0x1C1A17)
+    static let surface = dynamic(light: 0xFFFFFF, dark: 0x26231F)
+    static let stroke = dynamic(light: 0xE8E2D8, dark: 0x3A352F)
+    static let textPrimary = dynamic(light: 0x2C2823, dark: 0xF2EEE6)
+    static let textSecondary = dynamic(light: 0x7A736B, dark: 0x9E978D)
+
+    static let morning = dynamic(light: 0xF5C56B, dark: 0xC9A157)
+    static let lunch = dynamic(light: 0xE89A78, dark: 0xB97155)
+    static let evening = dynamic(light: 0x7B6BA8, dark: 0x5E5283)
+
+    static func dynamic(light: UInt32, dark: UInt32) -> Color {
+        Color(uiColor: UIColor { trait in
+            trait.userInterfaceStyle == .dark ? UIColor(hex: dark) : UIColor(hex: light)
+        })
+    }
+}
+
+private extension UIColor {
+    convenience init(hex: UInt32) {
+        let r = CGFloat((hex >> 16) & 0xFF) / 255.0
+        let g = CGFloat((hex >> 8) & 0xFF) / 255.0
+        let b = CGFloat(hex & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b, alpha: 1.0)
+    }
+}

--- a/ios/PillPouch/DesignSystem/Tokens/Spacing.swift
+++ b/ios/PillPouch/DesignSystem/Tokens/Spacing.swift
@@ -1,0 +1,10 @@
+import CoreGraphics
+
+enum PPSpacing {
+    static let xs: CGFloat = 4
+    static let sm: CGFloat = 8
+    static let md: CGFloat = 16
+    static let lg: CGFloat = 24
+    static let xl: CGFloat = 32
+    static let xxl: CGFloat = 48
+}

--- a/ios/PillPouch/DesignSystem/Tokens/Typography.swift
+++ b/ios/PillPouch/DesignSystem/Tokens/Typography.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+enum PPFont {
+    static let titleL: Font = .system(.largeTitle, design: .rounded).weight(.semibold)
+    static let titleM: Font = .system(.title2, design: .rounded).weight(.semibold)
+    static let body: Font = .system(.body, design: .rounded)
+    static let caption: Font = .system(.caption, design: .rounded)
+    static let mono: Font = .system(.body, design: .monospaced)
+}


### PR DESCRIPTION
## Why
W1-4 deliverable. 기획서 §시각 언어가 brief에만 있고 시각 수치 SoT가 부재했음 — 봉지/캡슐/색/햅틱 결정이 W2 (L) 가로 드래그 task 진입 전 박제되어야 후속 컴포넌트 구현이 일관됨. 동시에 iOS 측에서 색·스페이싱·타이포 토큰을 코드화해 향후 모든 화면이 동일 토큰 import.

## What

### 문서
- `docs/design-system.md` stub → **11개 섹션 SoT** 채움:
  - SoT 위계 (brief 1순위 / design-system 2순위 / Swift 토큰 3순위)
  - 색 토큰 (라이트+다크 hex, 시간대 색조 morning/lunch/evening, 채도 감소 공식 `S × (1−p)`)
  - 타이포(`.rounded` Dynamic Type 5 토큰), 스페이싱(8pt grid 6 토큰)
  - 봉지 5상태 시각 명세 (비율 100:32, V컷 22%, sine 2.0pt, 5상태 변형 표) — W2 (L) 가로 드래그 입력값
  - 캡슐 6종 SVG 명세 + **GPT Image 2 프롬프트 6개** + 정리·등록 워크플로우 → 자산 제작은 별도 [#11](https://github.com/kswift1/PillPouch/issues/11)
  - 햅틱 시퀀스 표 (진행도별 generator/intensity/횟수)
  - 하지 말아야 할 시각 결정 14개

### 코드 (`ios/PillPouch/DesignSystem/Tokens/`)
- `Color+Tokens.swift` — `PPColor` enum, UITraitCollection 기반 라이트/다크 동적 색 8 토큰 (background/surface/stroke/textPrimary/textSecondary + morning/lunch/evening)
- `Spacing.swift` — `PPSpacing` 8pt grid (xs=4 ~ xxl=48)
- `Typography.swift` — `PPFont` `.rounded` design 5 토큰 + mono

PBXFileSystemSynchronizedRootGroup(Xcode 16+)으로 자동 등록 — pbxproj 수정 0회.

## Test plan
- [x] 로컬 빌드 통과 — `xcodebuild -scheme PillPouch -sdk iphonesimulator ... build` BUILD SUCCEEDED
- [x] 신규 테스트 — 토큰 상수만이라 unit test 불필요 (W2 컴포넌트와 함께 snapshot test 도입 예정)
- [x] UI 변경 X — 토큰 노출만, 적용은 W1-5 Today 화면 task에서
- [ ] CI 통과 (ios-build paths filter trigger 예상)

## Screenshots
해당 없음 — 토큰 노출만, UI 변경 X.

## Linked docs (M)
- 구현계획서: [`docs/plans/task_W1_9_impl.md`](docs/plans/task_W1_9_impl.md)
- 최종보고서: [`docs/report/task_W1_9_report.md`](docs/report/task_W1_9_report.md)

## 가설 검증 체크 (Pill Pouch 정체성 보호)
- [x] 이 변경은 가설 B(기록 신뢰성)를 강화한다 — 시간대 색조·봉지 5상태 명세 박제로 "찢김 = 비가역적 시각 증거" 시각 토대 구축. 14개 금기로 후속 PR 가드레일.
- [x] Non-goals(`docs/brief.md` §Non-goals)에 해당하지 않는다 — TCA·Carousel·단순 탭 어느 항목도 추가 X.
- [x] 가설 약화 가능성 없음 — ADR 불필요.

## 기타
- 사이즈: +700 LOC (대부분 design-system.md 본문). 분할 가치 낮음 (단일 SoT 문서).
- 머지: Squash.
- 후속: [#11](https://github.com/kswift1/PillPouch/issues/11) (W2 캡슐 자산), W2 (M) 봉지 5상태 컴포넌트, W2 (L) 가로 드래그 task에서 본 토큰/명세 사용.

Closes #9